### PR TITLE
Fix duplicate prebuild script

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,8 +9,7 @@
     "preview": "astro preview",
     "astro": "astro",
     "add-slugs": "tsx scripts/add-slugs.ts",
-    "generate-og-images": "tsx scripts/generate-og-images.ts",
-    "prebuild": "npm run generate-og-images"
+    "generate-og-images": "tsx scripts/generate-og-images.ts"
   },
   "dependencies": {
     "@astrojs/mdx": "^4.2.3",


### PR DESCRIPTION
## Summary
- remove redundant `prebuild` entry from `package.json`

## Testing
- `npm run build` *(fails: process interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_6843332ddaf4832aacbe56d909c9f85c